### PR TITLE
#39 10K editions - fixed async issue to generate 10k images 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -125,12 +125,12 @@ const drawLayer = async (_layer, _edition) => {
   }
 };
 
-const createFiles = edition => {
+const createFiles = async edition => {
   const layers = layersSetup(layersOrder);
 
   for (let i = 1; i <= edition; i++) {
-    layers.forEach((layer) => {
-      drawLayer(layer, i);
+    await layers.forEach( async(layer) => {
+      await drawLayer(layer, i);
     });
     addMetadata(i);
     console.log("Creating edition " + i);


### PR DESCRIPTION
Fixed the higher memory usage and a crash issue when a large number of images are created. 

Tested with 10k Images without any issue.
