### PR TITLE
individual metadata json files are created for each image

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -93,6 +93,10 @@ const addMetadata = _edition => {
   attributes = [];
   hash = [];
   decodedHash = [];
+  fs.writeFileSync(
+    `${buildDir}/${_edition}.json`,
+    JSON.stringify(tempMetadata, null, 2)
+  );
 };
 
 const addAttributes = (_element, _layer) => {


### PR DESCRIPTION
Individual metadata json files are created for each image for easy uploading.

Note: The original _metadata.json file is still generated in the build directory and the the current attribute format still does not match the OpenSea Metadata Standards
https://docs.opensea.io/docs/metadata-standards