### PR TITLE
🐛  Reset Canvas on each pass of drawing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,8 @@ const { createCanvas, loadImage } = require("canvas");
 const console = require("console");
 const { layersOrder, format, rarity } = require("./config.js");
 
-const canvas = createCanvas(format.width, format.height);
-const ctx = canvas.getContext("2d");
+let canvas;
+let ctx;
 
 if (!process.env.PWD) {
   process.env.PWD = process.cwd();
@@ -132,6 +132,9 @@ const createFiles = async edition => {
 
   let numDupes = 0;
  for (let i = 1; i <= edition; i++) {
+   canvas = createCanvas(format.width, format.height);
+   ctx = canvas.getContext("2d");
+
    await layers.forEach(async (layer) => {
      await drawLayer(layer, i);
    });


### PR DESCRIPTION
I have an issue. I would have final transparent PNG rendered. And now, all layer is printed into the same canvas.

Such a simple solution to have a final transparent PNG. And this will help to accelerate the rendering for each picture.